### PR TITLE
build: Allow disable tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,7 +55,9 @@ pkg.generate(filebase: api_name, libraries: [main_library],
     url: 'http://endlessm.github.io/libcog',
     version: meson.project_version())
 
-subdir('test')
+if get_option('test')
+    subdir('test')
+endif
 
 if get_option('documentation')
     subdir('docs')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,9 @@
 option('documentation', type: 'boolean', value: false,
   description: 'Build and install documentation')
 
+option('test', type: 'boolean', value: true,
+  description: 'Run tests after compile')
+
 option('jasmine_junit_reports_dir', type: 'string',
     description: 'Where to put test reports')
 


### PR DESCRIPTION
The jasmine dependency is a hard dependency because the meson script
runs the tests after the build. This option allow to disable the tests
so it's possible to compile the library for production without the
jasmine dependency.